### PR TITLE
store: add query hints to &sb

### DIFF
--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -387,6 +387,8 @@ func findMostMatchingKey(stores []Client, r *storepb.SeriesRequest, listeners *l
 		fmt.Fprintf(&sb, "%s%c%s%c", m.Name, marker, m.Value, marker)
 	}
 
+	fmt.Fprintf(&sb, "%v", r.QueryHints)
+
 	_, ok := listeners.Get(sb.String())
 	// Easy path - direct match.
 	if ok {


### PR DESCRIPTION
Add query hints so that we wouldn't unexpectedly reuse response from a
semantically different request. (pushdown vs. no pushdown)

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>
